### PR TITLE
ikonli FontAwesome pack as a source for IMAGE in NAVIGATOR

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -243,12 +243,12 @@
         <dependency>
             <groupId>org.kordamp.ikonli</groupId>
             <artifactId>ikonli-swing</artifactId>
-            <version>11.3.5-8</version>
+            <version>11.3.5-9</version>
         </dependency>
         <dependency>
             <groupId>org.kordamp.ikonli</groupId>
             <artifactId>ikonli-fontawesome-pack</artifactId>
-            <version>11.3.5-8</version>
+            <version>11.3.5-9</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.geocoder-java</groupId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -239,7 +239,17 @@
             <groupId>com.twelvemonkeys.imageio</groupId>
             <artifactId>imageio-jpeg</artifactId>
         </dependency>
-
+        <!--Font Awesome Icons-->
+        <dependency>
+            <groupId>org.kordamp.ikonli</groupId>
+            <artifactId>ikonli-swing</artifactId>
+            <version>11.3.5-8</version>
+        </dependency>
+        <dependency>
+            <groupId>org.kordamp.ikonli</groupId>
+            <artifactId>ikonli-fontawesome-pack</artifactId>
+            <version>11.3.5-8</version>
+        </dependency>
         <dependency>
             <groupId>com.google.code.geocoder-java</groupId>
             <artifactId>geocoder-java</artifactId>

--- a/server/src/main/java/lsfusion/server/logics/navigator/NavigatorElement.java
+++ b/server/src/main/java/lsfusion/server/logics/navigator/NavigatorElement.java
@@ -20,17 +20,24 @@ import lsfusion.server.physics.admin.authentication.security.policy.SecurityPoli
 import lsfusion.server.physics.dev.debug.DebugInfo;
 import lsfusion.server.physics.dev.i18n.LocalizedString;
 import lsfusion.server.physics.dev.id.name.CanonicalNameUtils;
+import org.kordamp.ikonli.swing.FontIcon;
+import org.kordamp.ikonli.fontawesome.FontAwesome;
 
 import javax.swing.*;
+import java.awt.*;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.*;
+import java.util.List;
 
 import static lsfusion.base.col.MapFact.mergeOrderMapsExcl;
 import static lsfusion.base.col.MapFact.singletonOrder;
 
 public abstract class NavigatorElement {
-    
+
+    public static final int DEFAULT_ICON_SIZE = 32;
+    public static final Color DEFAULT_ICON_COLOR = Color.DARK_GRAY;
+
     private SerializableImageIconHolder imageHolder;
     public DefaultIcon defaultIcon;
 
@@ -209,7 +216,16 @@ public abstract class NavigatorElement {
     }
 
     public final void setImage(String imagePath, DefaultIcon defaultIcon) {
-        ImageIcon image = ResourceUtils.readImage(imagePath);
+        ImageIcon image = null;
+
+        //FontAwesome pack - pattern ^fa-[^\.]*
+        if (imagePath.startsWith("fa-") && !imagePath.contains(".")) {
+            FontIcon fi  = FontIcon.of(FontAwesome.findByDescription(imagePath), DEFAULT_ICON_SIZE, DEFAULT_ICON_COLOR);
+            image = new ImageIcon(fi.getImage());
+        } else {
+            image = ResourceUtils.readImage(imagePath);
+        }
+
         if (image != null) {
             imageHolder = new SerializableImageIconHolder(image, imagePath);
             this.defaultIcon = defaultIcon;

--- a/server/src/main/java/lsfusion/server/logics/navigator/NavigatorElement.java
+++ b/server/src/main/java/lsfusion/server/logics/navigator/NavigatorElement.java
@@ -25,6 +25,7 @@ import org.kordamp.ikonli.fontawesome.FontAwesome;
 
 import javax.swing.*;
 import java.awt.*;
+import java.awt.image.BufferedImage;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.*;
@@ -216,12 +217,15 @@ public abstract class NavigatorElement {
     }
 
     public final void setImage(String imagePath, DefaultIcon defaultIcon) {
-        ImageIcon image = null;
+        ImageIcon image;
 
         //FontAwesome pack - pattern ^fa-[^\.]*
         if (imagePath.startsWith("fa-") && !imagePath.contains(".")) {
+            BufferedImage iconImage = new BufferedImage(DEFAULT_ICON_SIZE, DEFAULT_ICON_SIZE, BufferedImage.TYPE_INT_ARGB);
             FontIcon fi  = FontIcon.of(FontAwesome.findByDescription(imagePath), DEFAULT_ICON_SIZE, DEFAULT_ICON_COLOR);
-            image = new ImageIcon(fi.getImage());
+            fi.paintIcon(null, iconImage.getGraphics(),0,0);
+
+            image = new ImageIcon(iconImage);
         } else {
             image = ResourceUtils.readImage(imagePath);
         }


### PR DESCRIPTION
Hello ! 
I propose to use font's pack as IMAGE sources.

Font packs originally created by kordamp (see https://github.com/kordamp/ikonli). I switched it to maven and modified a little bit to produce Image (see FontIcon getImage() method https://github.com/ValentinChirikov/ikonli-maven-java8) that ImageIcon constructor consumes (see NavigatorElement setImage method). 

To produce a build ikonli-maven-java8 must be cloned and artifacts pushed to repo. 

Then it could be called from LSF : 
NAVIGATOR {
    NEW MainForm FIRST;
    NEW Teams IMAGE 'fa-users' AFTER MainForm;
}

![Аннотация 2020-03-05 115120](https://user-images.githubusercontent.com/33689101/75964092-ab1cea80-5ed7-11ea-889c-1b1ded9990e5.jpg)

The cheat-sheet for icons http://kordamp.org/ikonli/cheat-sheet-fontawesome.html

If You like idea please give some feedback. Thanks. 