### PR TITLE
[web] 'ENTER' like 'TAB' behaviour for panel properties

### DIFF
--- a/web-client/src/main/java/lsfusion/gwt/client/form/controller/GFormController.java
+++ b/web-client/src/main/java/lsfusion/gwt/client/form/controller/GFormController.java
@@ -1540,6 +1540,19 @@ public class GFormController extends ResizableSimplePanel implements ServerMessa
         bindings.remove(index);
     }
 
+    public void addEnterBindings(GBindingMode bindGroup, Consumer<Boolean> selectNextElement, GGroupObject groupObject) {
+        addEnterBinding(false, bindGroup, selectNextElement, groupObject);
+        addEnterBinding(true, bindGroup, selectNextElement, groupObject);
+    }
+
+    private void addEnterBinding(boolean shiftPressed, GBindingMode bindGroup, Consumer<Boolean> selectNextElement, GGroupObject groupObject) {
+        addBinding(new GKeyInputEvent(new GKeyStroke(KeyCodes.KEY_ENTER, false, false, shiftPressed)),
+                new GBindingEnv(-100, null, null, bindGroup, GBindingMode.NO, null),  // bindEditing - NO, because we don't want for example when editing text in grid to catch enter
+                event -> selectNextElement.accept(!shiftPressed),
+                null,
+                groupObject);
+    }
+
     private GGroupObject getGroupObject(Element elementTarget) {
         while (elementTarget != null) {     // пытаемся найти GroupObject, к которому относится элемент с фокусом
             GGroupObject targetGO = (GGroupObject) elementTarget.getPropertyObject("groupObject");

--- a/web-client/src/main/java/lsfusion/gwt/client/form/object/panel/controller/GPanelController.java
+++ b/web-client/src/main/java/lsfusion/gwt/client/form/object/panel/controller/GPanelController.java
@@ -1,9 +1,14 @@
 package lsfusion.gwt.client.form.object.panel.controller;
 
-import lsfusion.gwt.client.GFormChanges;
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.event.dom.client.KeyCodes;
 import lsfusion.gwt.client.base.jsni.NativeHashMap;
 import lsfusion.gwt.client.base.jsni.NativeSIDMap;
 import lsfusion.gwt.client.form.controller.GFormController;
+import lsfusion.gwt.client.form.event.GBindingEnv;
+import lsfusion.gwt.client.form.event.GBindingMode;
+import lsfusion.gwt.client.form.event.GKeyInputEvent;
+import lsfusion.gwt.client.form.event.GKeyStroke;
 import lsfusion.gwt.client.form.object.GGroupObjectValue;
 import lsfusion.gwt.client.form.object.table.controller.GPropertyController;
 import lsfusion.gwt.client.form.property.*;
@@ -16,7 +21,25 @@ public class GPanelController extends GPropertyController {
 
     public GPanelController(GFormController formController) {
         super(formController);
+
+        addEnterBinding(true);
+        addEnterBinding(false);
     }
+
+    private void addEnterBinding(boolean shiftPressed) {
+        formController.addBinding(new GKeyInputEvent(new GKeyStroke(KeyCodes.KEY_ENTER, false, false, shiftPressed)),
+                new GBindingEnv(-100, null, null, GBindingMode.ALL, GBindingMode.NO, null),  // bindEditing - NO, because we don't want for example when editing text in grid to catch enter
+                event -> getNextSelectedElement(formController.getElement(), shiftPressed).focus(),
+                null, null);
+    }
+
+    private native Element getNextSelectedElement(Element formController, boolean shiftPressed) /*-{
+        var elements = Array.prototype.filter.call(formController.querySelectorAll('div'), function (item) {
+            return item.tabIndex >= "0"
+        });
+        var index = elements.indexOf($doc.activeElement);
+        return shiftPressed ? (elements[index - 1] || elements[elements.length - 1]) : (elements[index + 1] || elements[0]);
+    }-*/;
 
     @Override
     public void updateProperty(GPropertyDraw property, ArrayList<GGroupObjectValue> columnKeys, boolean updateKeys, NativeHashMap<GGroupObjectValue, Object> values) {

--- a/web-client/src/main/java/lsfusion/gwt/client/form/object/panel/controller/GPanelController.java
+++ b/web-client/src/main/java/lsfusion/gwt/client/form/object/panel/controller/GPanelController.java
@@ -1,14 +1,10 @@
 package lsfusion.gwt.client.form.object.panel.controller;
 
 import com.google.gwt.dom.client.Element;
-import com.google.gwt.event.dom.client.KeyCodes;
 import lsfusion.gwt.client.base.jsni.NativeHashMap;
 import lsfusion.gwt.client.base.jsni.NativeSIDMap;
 import lsfusion.gwt.client.form.controller.GFormController;
-import lsfusion.gwt.client.form.event.GBindingEnv;
 import lsfusion.gwt.client.form.event.GBindingMode;
-import lsfusion.gwt.client.form.event.GKeyInputEvent;
-import lsfusion.gwt.client.form.event.GKeyStroke;
 import lsfusion.gwt.client.form.object.GGroupObjectValue;
 import lsfusion.gwt.client.form.object.table.controller.GPropertyController;
 import lsfusion.gwt.client.form.property.*;
@@ -22,23 +18,19 @@ public class GPanelController extends GPropertyController {
     public GPanelController(GFormController formController) {
         super(formController);
 
-        addEnterBinding(true);
-        addEnterBinding(false);
+        formController.addEnterBindings(GBindingMode.ALL, this::selectNextElement, null);
     }
 
-    private void addEnterBinding(boolean shiftPressed) {
-        formController.addBinding(new GKeyInputEvent(new GKeyStroke(KeyCodes.KEY_ENTER, false, false, shiftPressed)),
-                new GBindingEnv(-100, null, null, GBindingMode.ALL, GBindingMode.NO, null),  // bindEditing - NO, because we don't want for example when editing text in grid to catch enter
-                event -> getNextSelectedElement(formController.getElement(), shiftPressed).focus(),
-                null, null);
+    private void selectNextElement(boolean forward) {
+        getNextSelectedElement(formController.getElement(), forward).focus();
     }
 
-    private native Element getNextSelectedElement(Element formController, boolean shiftPressed) /*-{
+    private native Element getNextSelectedElement(Element formController, boolean forward) /*-{
         var elements = Array.prototype.filter.call(formController.querySelectorAll('div'), function (item) {
             return item.tabIndex >= "0"
         });
         var index = elements.indexOf($doc.activeElement);
-        return shiftPressed ? (elements[index - 1] || elements[elements.length - 1]) : (elements[index + 1] || elements[0]);
+        return forward ? (elements[index + 1] || elements[0]) : (elements[index - 1] || elements[elements.length - 1]);
     }-*/;
 
     @Override

--- a/web-client/src/main/java/lsfusion/gwt/client/form/property/table/view/GPropertyTable.java
+++ b/web-client/src/main/java/lsfusion/gwt/client/form/property/table/view/GPropertyTable.java
@@ -1,13 +1,14 @@
 package lsfusion.gwt.client.form.property.table.view;
 
-import com.google.gwt.dom.client.*;
-import com.google.gwt.event.dom.client.KeyCodes;
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.TableCellElement;
 import lsfusion.gwt.client.base.view.EventHandler;
 import lsfusion.gwt.client.base.view.grid.DataGrid;
 import lsfusion.gwt.client.base.view.grid.GridStyle;
+import lsfusion.gwt.client.base.view.grid.cell.Cell;
 import lsfusion.gwt.client.form.controller.GFormController;
 import lsfusion.gwt.client.form.design.GFont;
-import lsfusion.gwt.client.form.event.*;
+import lsfusion.gwt.client.form.event.GBindingMode;
 import lsfusion.gwt.client.form.object.GGroupObject;
 import lsfusion.gwt.client.form.object.GGroupObjectValue;
 import lsfusion.gwt.client.form.object.table.view.GGridPropertyTable;
@@ -20,10 +21,6 @@ import lsfusion.gwt.client.form.property.cell.view.UpdateContext;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import static lsfusion.gwt.client.base.GwtClientUtils.stopPropagation;
-
-import lsfusion.gwt.client.base.view.grid.cell.Cell;
 
 public abstract class GPropertyTable<T extends GridDataRecord> extends DataGrid<T> implements RenderContext, UpdateContext {
 
@@ -38,17 +35,8 @@ public abstract class GPropertyTable<T extends GridDataRecord> extends DataGrid<
 
         //  Have the enter key work the same as the tab key
         if(groupObject != null) {
-            addEnterBinding(false);
-            addEnterBinding(true);
+            form.addEnterBindings(GBindingMode.ONLY, ((GGridPropertyTable) GPropertyTable.this)::selectNextCellInColumn, groupObject);
         }
-    }
-
-    private void addEnterBinding(boolean shiftPressed) {
-        form.addBinding(new GKeyInputEvent(new GKeyStroke(KeyCodes.KEY_ENTER, false, false, shiftPressed)),
-                new GBindingEnv(-100, null, null, GBindingMode.ONLY, GBindingMode.NO, null),  // bindEditing - NO, because we don't want for example when editing text in grid to catch enter
-                event -> ((GGridPropertyTable) GPropertyTable.this).selectNextCellInColumn(!shiftPressed),
-                null,
-                groupObject);
     }
 
     public abstract boolean isReadOnly(Cell cell);


### PR DESCRIPTION
[web] 'ENTER' like 'TAB' behaviour for panel properties