### PR TITLE
Single modalMask for multiple modal windows

### DIFF
--- a/web-client/src/main/java/lsfusion/gwt/client/base/view/ResizableModalWindow.java
+++ b/web-client/src/main/java/lsfusion/gwt/client/base/view/ResizableModalWindow.java
@@ -1,68 +1,56 @@
 package lsfusion.gwt.client.base.view;
 
-import com.google.gwt.dom.client.Element;
-import com.google.gwt.dom.client.EventTarget;
-import com.google.gwt.dom.client.NativeEvent;
-import com.google.gwt.event.logical.shared.CloseEvent;
-import com.google.gwt.event.logical.shared.CloseHandler;
-import com.google.gwt.event.shared.HandlerRegistration;
-import com.google.gwt.user.client.Event;
+import com.google.gwt.user.client.ui.AbsolutePanel;
 import com.google.gwt.user.client.ui.PopupPanel;
-import lsfusion.gwt.client.base.GwtClientUtils;
+import com.google.gwt.user.client.ui.Widget;
+import lsfusion.gwt.client.base.Pair;
+import lsfusion.gwt.client.form.view.ModalForm;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class ResizableModalWindow extends ResizableWindow {
 
-    private ModalMask modalMask;
-//    private HandlerRegistration nativePreviewHandlerReg;
+    private static ModalMask modalMask;
+    private static Map<Widget, Pair<ModalForm, Long>> formRequestIndexMap = new HashMap<>();
 
-    @Override
-    public void show() {
+    public void showModal(Pair<ModalForm, Long> formRequestIndex, Integer insertIndex) {
+        showModalMask(formRequestIndex);
+        super.show(insertIndex);
+    }
+
+    public Pair<ModalForm, Integer> getFormInsertIndex(Long requestIndex) {
+        AbsolutePanel boundaryPanel = getBoundaryPanel();
+        for(int i = 0; i < boundaryPanel.getWidgetCount(); i++) {
+            Widget widget = boundaryPanel.getWidget(i);
+            Pair<ModalForm, Long> form = formRequestIndexMap.get(widget);
+            if(form != null && form.second != null && form.second < requestIndex) {
+                return new Pair(form.first, i);
+            }
+        }
+        return null;
+    }
+
+    public void hideModal() {
+        super.hide();
+        hideModalMask();
+    }
+
+    public void showModalMask(Pair<ModalForm, Long> formRequestIndex) {
         if (modalMask == null) {
             modalMask = new ModalMask();
             modalMask.show();
         }
-
-//        breaks resize and not sure what it's for
-//        nativePreviewHandlerReg = Event.addNativePreviewHandler(this::previewNativeEvent);
-
-        super.show();
+        formRequestIndexMap.put(this, formRequestIndex);
     }
 
-    @Override
-    public void hide() {
-        super.hide();
-
-//        if (nativePreviewHandlerReg != null) { // как-то словили NPE
-//            nativePreviewHandlerReg.removeHandler();
-//            nativePreviewHandlerReg = null;
-//        }
-
-        if (modalMask != null) {
+    public void hideModalMask() {
+        formRequestIndexMap.remove(this);
+        if (modalMask != null && formRequestIndexMap.isEmpty()) {
             modalMask.hide();
             modalMask = null;
         }
     }
-
-//    private boolean eventTargetsPopup(NativeEvent event) {
-//        EventTarget target = event.getEventTarget();
-//        return Element.is(target) && getElement().isOrHasChild(Element.as(target));
-//    }
-//
-//    private void previewNativeEvent(Event.NativePreviewEvent event) {
-//        // If the event has been canceled or consumed, ignore it
-//        if (event.isCanceled() || event.isConsumed()) {
-//            return;
-//        }
-//
-//        // If the event targets the popup, consume it
-//        Event nativeEvent = Event.as(event.getNativeEvent());
-//        if (eventTargetsPopup(nativeEvent)) {
-//            event.consume();
-//        } else {
-//            // Cancel the event if it doesn't target the modal popup.
-//            event.cancel();
-//        }
-//    }
 
     private final static class ModalMask {
         private final PopupPanel popup;

--- a/web-client/src/main/java/lsfusion/gwt/client/base/view/ResizableModalWindow.java
+++ b/web-client/src/main/java/lsfusion/gwt/client/base/view/ResizableModalWindow.java
@@ -12,9 +12,11 @@ import java.util.Map;
 public class ResizableModalWindow extends ResizableWindow {
 
     private static ModalMask modalMask;
+    //This scheme is necessary when one modal window is started before the second one, but is displayed later due to delays.
+    //In this case, the order in which the windows are displayed must be maintained according to the order of request indexes.
     private static Map<Widget, Pair<ModalForm, Long>> formRequestIndexMap = new HashMap<>();
 
-    public void showModal(Pair<ModalForm, Long> formRequestIndex, Integer insertIndex) {
+    public void show(Pair<ModalForm, Long> formRequestIndex, Integer insertIndex) {
         showModalMask(formRequestIndex);
         super.show(insertIndex);
     }
@@ -31,7 +33,7 @@ public class ResizableModalWindow extends ResizableWindow {
         return null;
     }
 
-    public void hideModal() {
+    public void hide() {
         super.hide();
         hideModalMask();
     }

--- a/web-client/src/main/java/lsfusion/gwt/client/base/view/ResizableWindow.java
+++ b/web-client/src/main/java/lsfusion/gwt/client/base/view/ResizableWindow.java
@@ -204,15 +204,25 @@ public class ResizableWindow extends Composite {
         setContentSize(innerContentWidget.getOffsetWidth(), innerContentWidget.getOffsetHeight());
     }
 
-    public void show() {
-        windowController.getBoundaryPanel().add(this); // attaching
+    public void show(Integer insertIndex) {
+        AbsolutePanel boundaryPanel = windowController.getBoundaryPanel();
+        // attaching
+        if(insertIndex != null) {
+            boundaryPanel.insert(this, insertIndex);
+        } else {
+            boundaryPanel.add(this);
+        }
         
         onShow(); // need it after attach to have actual sizes calculated
 
         // centering, has to be done after everything is calculated
-        windowController.getBoundaryPanel().setWidgetPosition(this,
+        boundaryPanel.setWidgetPosition(this,
                 (Window.getClientWidth() - getOffsetWidth()) / 2,
                 (Window.getClientHeight() - getOffsetHeight()) / 2);
+    }
+
+    public AbsolutePanel getBoundaryPanel() {
+        return windowController.getBoundaryPanel();
     }
 
     public enum Direction {

--- a/web-client/src/main/java/lsfusion/gwt/client/form/EmbeddedForm.java
+++ b/web-client/src/main/java/lsfusion/gwt/client/form/EmbeddedForm.java
@@ -111,7 +111,7 @@ public class EmbeddedForm extends EditingForm {
     }
 
     @Override
-    public void show(Integer index) {
+    public void show(Long requestIndex, Integer index) {
         // we don't need to change currentForm for embedded form, since if closes on focus lost, so we don't need notifications / global key events
         // for the same reason we don't need to do onBlur
         // however now it's hard to tell what is the right approach

--- a/web-client/src/main/java/lsfusion/gwt/client/form/PopupForm.java
+++ b/web-client/src/main/java/lsfusion/gwt/client/form/PopupForm.java
@@ -77,7 +77,7 @@ public class PopupForm extends EditingForm {
     private FormContainer prevForm;
 
     @Override
-    public void show(Integer index) {
+    public void show(Long requestIndex, Integer index) {
         prevForm = MainFrame.getAssertCurrentForm();
         if(prevForm != null) // if there were no currentForm
             prevForm.onBlur(false);

--- a/web-client/src/main/java/lsfusion/gwt/client/form/controller/FormsController.java
+++ b/web-client/src/main/java/lsfusion/gwt/client/form/controller/FormsController.java
@@ -133,7 +133,7 @@ public abstract class FormsController {
         if (asyncFormController.onServerInvocationCloseResponse()) {
             if (Arrays.stream(response.actions).noneMatch(a -> a instanceof GHideFormAction)) {
                 Pair<FormContainer, Integer> asyncClosedForm = asyncFormController.removeAsyncClosedForm();
-                asyncClosedForm.first.show(asyncClosedForm.second);
+                asyncClosedForm.first.show(null, asyncClosedForm.second);
             }
         }
     }
@@ -222,7 +222,7 @@ public abstract class FormsController {
         if(asyncOpened)
             formContainer.onAsyncInitialized();
         else
-            formContainer.show();
+            formContainer.show(asyncFormController.getEditRequestIndex());
 
         return formContainer;
     }
@@ -248,7 +248,7 @@ public abstract class FormsController {
             Scheduler.ScheduledCommand runOpenForm = () -> {
                 FormContainer formContainer = createFormContainer(windowType, true, asyncFormController.getEditRequestIndex(), openForm.canonicalName, openForm.caption, editEvent, editContext, formController);
                 formContainer.setContentLoading();
-                formContainer.show();
+                formContainer.show(asyncFormController.getEditRequestIndex());
                 asyncFormController.putAsyncForm(formContainer);
             };
             // this types because for them size is unknown, so there'll be blinking

--- a/web-client/src/main/java/lsfusion/gwt/client/form/controller/FormsController.java
+++ b/web-client/src/main/java/lsfusion/gwt/client/form/controller/FormsController.java
@@ -133,7 +133,7 @@ public abstract class FormsController {
         if (asyncFormController.onServerInvocationCloseResponse()) {
             if (Arrays.stream(response.actions).noneMatch(a -> a instanceof GHideFormAction)) {
                 Pair<FormContainer, Integer> asyncClosedForm = asyncFormController.removeAsyncClosedForm();
-                asyncClosedForm.first.show(null, asyncClosedForm.second);
+                asyncClosedForm.first.show(asyncFormController.getEditRequestIndex(), asyncClosedForm.second);
             }
         }
     }

--- a/web-client/src/main/java/lsfusion/gwt/client/form/view/FormContainer.java
+++ b/web-client/src/main/java/lsfusion/gwt/client/form/view/FormContainer.java
@@ -79,11 +79,11 @@ public abstract class FormContainer {
         }
     }
 
-    public void show() {
-        show(null);
+    public void show(Long requestIndex) {
+        show(requestIndex, null);
     }
 
-    public abstract void show(Integer index);
+    public abstract void show(Long requestIndex, Integer index);
 
     // server response reaction - hideFormAction dispatch, and incorrect modalitytype when getting form, or no form at all
     public void queryHide(EndReason editFormCloseReason) {

--- a/web-client/src/main/java/lsfusion/gwt/client/form/view/FormDockable.java
+++ b/web-client/src/main/java/lsfusion/gwt/client/form/view/FormDockable.java
@@ -56,7 +56,7 @@ public final class FormDockable extends FormContainer {
     }
 
     @Override
-    public void show(Integer index) {
+    public void show(Long requestIndex, Integer index) {
         formsController.addDockable(this, index);
     }
 

--- a/web-client/src/main/java/lsfusion/gwt/client/form/view/ModalForm.java
+++ b/web-client/src/main/java/lsfusion/gwt/client/form/view/ModalForm.java
@@ -66,7 +66,7 @@ public class ModalForm extends FormContainer {
     @Override
     public void onAsyncInitialized() {
         // actually it's already shown, but we want to update preferred sizes after setting the content
-        contentWidget.showModal(null, null);
+        contentWidget.show(null, null);
 
         super.onAsyncInitialized();
     }
@@ -83,7 +83,7 @@ public class ModalForm extends FormContainer {
             formInsertIndex.first.prevForm = this;
         }
 
-        contentWidget.showModal(new Pair(this, requestIndex), formInsertIndex != null ? formInsertIndex.second : null);
+        contentWidget.show(new Pair(this, requestIndex), formInsertIndex != null ? formInsertIndex.second : null);
 
         if(formInsertIndex == null) {
             onFocus(true);
@@ -96,7 +96,7 @@ public class ModalForm extends FormContainer {
     public void hide(EndReason editFormCloseReason) {
         onBlur(true);
 
-        contentWidget.hideModal();
+        contentWidget.hide();
 
         if(prevForm != null)
             prevForm.onFocus(false);

--- a/web-client/src/main/java/lsfusion/gwt/client/form/view/ModalForm.java
+++ b/web-client/src/main/java/lsfusion/gwt/client/form/view/ModalForm.java
@@ -5,7 +5,7 @@ import com.google.gwt.user.client.Event;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Widget;
 import lsfusion.gwt.client.base.Dimension;
-import lsfusion.gwt.client.base.GwtClientUtils;
+import lsfusion.gwt.client.base.Pair;
 import lsfusion.gwt.client.base.view.ResizableModalWindow;
 import lsfusion.gwt.client.form.controller.FormsController;
 import lsfusion.gwt.client.form.property.cell.controller.EndReason;
@@ -66,29 +66,37 @@ public class ModalForm extends FormContainer {
     @Override
     public void onAsyncInitialized() {
         // actually it's already shown, but we want to update preferred sizes after setting the content
-        contentWidget.show();
+        contentWidget.showModal(null, null);
 
         super.onAsyncInitialized();
     }
 
     @Override
-    public void show(Integer index) {
-        prevForm = MainFrame.getAssertCurrentForm();
-        if(prevForm != null) // if there were no currentForm
-            prevForm.onBlur(false);
+    public void show(Long requestIndex, Integer index) {
+        Pair<ModalForm, Integer> formInsertIndex = contentWidget.getFormInsertIndex(requestIndex);
+        if(formInsertIndex == null) {
+            prevForm = MainFrame.getAssertCurrentForm();
+            if (prevForm != null) // if there were no currentForm
+                prevForm.onBlur(false);
+        } else {
+            prevForm = formInsertIndex.first.prevForm;
+            formInsertIndex.first.prevForm = this;
+        }
 
-        contentWidget.show();
+        contentWidget.showModal(new Pair(this, requestIndex), formInsertIndex != null ? formInsertIndex.second : null);
 
-        onFocus(true);
-        if(async)
-            contentWidget.focus();
+        if(formInsertIndex == null) {
+            onFocus(true);
+            if(async)
+                contentWidget.focus();
+        }
     }
 
     @Override
     public void hide(EndReason editFormCloseReason) {
         onBlur(true);
 
-        contentWidget.hide();
+        contentWidget.hideModal();
 
         if(prevForm != null)
             prevForm.onFocus(false);


### PR DESCRIPTION
fixed case when one modal window is started before the second one, but is displayed later due to delays.
In this case, the order in which the windows are displayed must be maintained according to the order of request indexes.
    