### PR TITLE
IMPORT CSV: use separator containing more then one symbol (use org.apache.commons.commons-csv instead of com.opencsv.opencsv)

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -294,9 +294,9 @@
             <version>2.1.0</version>
         </dependency>
         <dependency>
-            <groupId>com.opencsv</groupId>
-            <artifactId>opencsv</artifactId>
-            <version>4.4</version>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-csv</artifactId>
+            <version>1.9.0</version>
         </dependency>
         <!--jwt token generation-->
         <dependency>


### PR DESCRIPTION
IMPORT CSV: use separator containing more then one symbol (use org.apache.commons.commons-csv instead of com.opencsv.opencsv)