### PR TITLE
Nested IMPORT FIELDS. Fixed a bug when using IMPORT FIELDS with the JSON type

### DIFF
--- a/server/src/main/antlr3/lsfusion/server/language/LsfLogics.g
+++ b/server/src/main/antlr3/lsfusion/server/language/LsfLogics.g
@@ -160,7 +160,25 @@ grammar LsfLogics;
 	public ScriptParser.State parseState;
 
 	private boolean insideRecursion = false;
-	
+
+    private String getRowParamName(List<TypedParameter> context) {
+        String base = "row";
+        String candidate = base;
+        int i = 2;
+        while (containsParamName(context, candidate)) {
+            candidate = base + i++;
+        }
+        return candidate;
+    }
+
+    private boolean containsParamName(List<TypedParameter> context, String name) {
+        for (TypedParameter p : context) {
+            if (name.equals(p.paramName))
+                return true;
+        }
+        return false;
+    }
+
 	public boolean inParseState(ScriptParser.State parseState) {
 		return this.parseState == parseState;
 	}
@@ -2574,7 +2592,7 @@ importActionDefinitionBody[List<TypedParameter> context, boolean dynamic] return
             {
                 if(inMainParseState()) {
                     if(fieldParams == null)
-                        fieldParams = Arrays.asList(TP("INTEGER", "row"));
+                        fieldParams = Arrays.asList(TP("INTEGER", getRowParamName(newContext)));
                     self.getParamIndices(fieldParams, newContext, true, insideRecursion);
                 }
             }

--- a/server/src/main/java/lsfusion/server/logics/classes/data/ArrayClass.java
+++ b/server/src/main/java/lsfusion/server/logics/classes/data/ArrayClass.java
@@ -77,7 +77,7 @@ public class ArrayClass<T> extends DataClass<T[]> implements DBType {
     }
 
     protected Class getReportJavaClass() {
-        throw new RuntimeException("not supported"); 
+        throw new RuntimeException("not supported");
     }
 
     public T[] parseString(String s) {
@@ -98,6 +98,6 @@ public class ArrayClass<T> extends DataClass<T[]> implements DBType {
     }
 
     public T[] getDefaultValue() {
-        throw new RuntimeException("not supported");
+        throw new UnsupportedOperationException();
     }
 }

--- a/server/src/main/java/lsfusion/server/logics/classes/data/TSQueryClass.java
+++ b/server/src/main/java/lsfusion/server/logics/classes/data/TSQueryClass.java
@@ -82,7 +82,7 @@ public class TSQueryClass extends DataClass<String> implements DBType {
 
     @Override
     public String getDefaultValue() {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/server/src/main/java/lsfusion/server/logics/classes/data/TSVectorClass.java
+++ b/server/src/main/java/lsfusion/server/logics/classes/data/TSVectorClass.java
@@ -91,7 +91,7 @@ public class TSVectorClass extends DataClass<Array> implements DBType {
 
     @Override
     public Array getDefaultValue() {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/server/src/main/java/lsfusion/server/logics/classes/data/file/AJSONClass.java
+++ b/server/src/main/java/lsfusion/server/logics/classes/data/file/AJSONClass.java
@@ -106,7 +106,7 @@ public abstract class AJSONClass extends FileBasedClass<String> implements DBTyp
 
     @Override
     public String getDefaultValue() {
-        return null;
+        return "{}";
     }
 
     @Override

--- a/server/src/main/java/lsfusion/server/logics/classes/struct/ConcatenateValueClass.java
+++ b/server/src/main/java/lsfusion/server/logics/classes/struct/ConcatenateValueClass.java
@@ -80,7 +80,7 @@ public class ConcatenateValueClass implements ValueClass {
     }
 
     public Object getDefaultValue() {
-        throw new RuntimeException("not supported");
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/server/src/main/java/lsfusion/server/logics/classes/user/CustomClass.java
+++ b/server/src/main/java/lsfusion/server/logics/classes/user/CustomClass.java
@@ -150,7 +150,7 @@ public abstract class CustomClass extends ImmutableObject implements ObjectClass
 
     @Override
     public Object getDefaultValue() {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override


### PR DESCRIPTION
```
  IMPORT JSON FROM f FIELDS JSON itemContent = content DO {
      printToLog(STRING(itemContent));
      IMPORT JSON FROM itemContent FIELDS STRING contentText = text DO {
          printToLog(contentText);
      }
  }

[
  {
    "content": [
      {
        "text": "nested_string_1"
      },
      {
        "text": "nested_string_1_2"
      }
    ]
  },
  {
    "content": [
      {
        "text": "nested_string_2"
      },
      {
        "text": "nested_string_2_2"
      }
    ]
  }
]
```