### PR TITLE
Fix HTTP 500 in newly opened web tab after restart caused by session id collision (closes #1643)

### DIFF
--- a/web-client/src/main/java/lsfusion/http/provider/navigator/NavigatorProviderImpl.java
+++ b/web-client/src/main/java/lsfusion/http/provider/navigator/NavigatorProviderImpl.java
@@ -170,7 +170,7 @@ public class NavigatorProviderImpl implements NavigatorProvider, DisposableBean 
 
     private AtomicInteger nextSessionId = new AtomicInteger(0);
     private String nextSessionID() {
-        return "session" + nextSessionId.getAndIncrement();
+        return "session" + servSID + nextSessionId.getAndIncrement();
     }
 
     private final Map<String, NavigatorSessionObject> currentLogicsAndNavigators = new ConcurrentHashMap<>();


### PR DESCRIPTION
NavigatorProviderImpl is session-scoped (one per browser), and the navigator session id was a per-instance counter starting at 0 ("session0", ...). After a web-server restart the counter resets, so a still-open old tab and a freshly opened tab could end up sharing the same provider and colliding on "session0", surfacing as a raw HTTP 500 in the new tab.

Include the random per-instance servSID in the id so it is unique across server restarts and provider instances; a stale tab now cleanly gets SessionInvalidatedException instead of colliding.